### PR TITLE
trix own `.envrc` now loads `./direnvrc` 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
+source direnvrc
 use trix


### PR DESCRIPTION
this way people clonning the repo and willing to contribute can just `direnv allow` without previously installing `./direnvrc` at `~/.config/direnv/lib`