### PR TITLE
Add reference to vic/with-inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,4 @@ RUST_LOG=trace trix build
   projects compatible with legacy Nix commands.
 - [unflake](https://codeberg.org/goldstein/unflake): An alternative dependency
   resolver & runtime for Nix flakes.
+- [with-inputs](https://github.com/vic/with-inputs): Flake compatible input resolution for projects not using flakes.


### PR DESCRIPTION
[with-inputs](https://github.com/vic/with-inputs) is related (alternative to nix flakes) in the sense that it allows flake-like inputs for projects using npins or other non-flake locking mechanism. 